### PR TITLE
Fixed #6, added ability to disable release on pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,47 @@ Install the plugin using the cordova command line utility:
 
 `$ cordova plugin add https://github.com/Viras-/cordova-plugin-powermanagement.git`
 
+Usage
+-----
+
+### window.powerManagement.acquire(successCallback, failureCallback)
+Acquire a wakelock by calling this.
+
+	window.powerManagement.acquire(function() {
+		console.log('Wakelock acquired');
+	}, function() {
+		console.log('Failed to acquire wakelock');
+	});
+
+### window.powerManagement.dim(successCallback, failureCallback)
+This acquires a partial wakelock, allowing the screen to be dimmed.
+
+	window.powerManagement.dim(function() {
+		console.log('Wakelock acquired');
+	}, function() {
+		console.log('Failed to acquire wakelock');
+	});
+
+### window.powerManagement.release(successCallback, failureCallback)
+Release the wakelock. It's important to do this when you're finished with the wakelock, to avoid unnecessary battery drain.
+
+	window.powerManagement.release(function() {
+		console.log('Wakelock released');
+	}, function() {
+		console.log('Failed to release wakelock');
+	});
+
+### [Android Only] window.powerManagement.setReleaseOnPause(enabled, successCallback, failureCallback)
+By default, the plugin will automatically release a wakelock when your app is paused (e.g. when the screen is turned off, or the user switches to another app). It will reacquire the wakelock upon app resume. If you would prefer to disable this behaviour, you can use this function.
+
+	window.powerManagement.setReleaseOnPause(false, function() {
+		console.log('Set successfully');
+	}, function() {
+		console.log('Failed to set');
+	});
+
+Note that in all the above examples, all callbacks are optional.
+
 License
 =======
 Copyright 2013 Wolfgang Koller

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
         id="at.gofg.sportscomputer.powermanagement"
-        version="1.0.0">
+        version="1.1.0">
     <name>PowerManagement</name>
     <description>PowerManagement plugin for Cordova</description>
     <license>Apache 2.0</license>
@@ -34,17 +34,17 @@
     </platform>
 
     <!-- ios -->
-    <platform name="ios">            
+    <platform name="ios">
         <config-file target="config.xml" parent="/widget">
             <feature name="PowerManagement">
-                <param name="ios-package" value="PowerManagement" /> 
+                <param name="ios-package" value="PowerManagement" />
             </feature>
         </config-file>
-    
+
         <header-file src="src/ios/PowerManagement.h" />
-        <source-file src="src/ios/PowerManagement.m" />   	
+        <source-file src="src/ios/PowerManagement.m" />
     </platform>
-    
+
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/PowerManagement.java
+++ b/src/android/PowerManagement.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013-2014 Wolfgang Koller
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,10 +48,10 @@ public class PowerManagement extends CordovaPlugin {
 	@Override
 	public void initialize(CordovaInterface cordova, CordovaWebView webView) {
 		super.initialize(cordova, webView);
-		
+
 		this.powerManager = (PowerManager) cordova.getActivity().getSystemService(Context.POWER_SERVICE);
 	}
-	
+
 	@Override
 	public boolean execute(String action, JSONArray args,
 			CallbackContext callbackContext) throws JSONException {
@@ -59,7 +59,7 @@ public class PowerManagement extends CordovaPlugin {
 		PluginResult result = null;
 		Log.d("PowerManagementPlugin", "Plugin execute called - " + this.toString() );
 		Log.d("PowerManagementPlugin", "Action is " + action );
-		
+
 		try {
 			if( action.equals("acquire") ) {
 					if( args.length() > 0 && args.getBoolean(0) ) {
@@ -77,11 +77,11 @@ public class PowerManagement extends CordovaPlugin {
 		catch( JSONException e ) {
 			result = new PluginResult(Status.JSON_EXCEPTION, e.getMessage());
 		}
-		
+
 		callbackContext.sendPluginResult(result);
 		return true;
 	}
-	
+
 	/**
 	 * Acquire a wake-lock
 	 * @param p_flags Type of wake-lock to acquire
@@ -89,7 +89,7 @@ public class PowerManagement extends CordovaPlugin {
 	 */
 	private PluginResult acquire( int p_flags ) {
 		PluginResult result = null;
-		
+
 		if (this.wakeLock == null) {
 			this.wakeLock = this.powerManager.newWakeLock(p_flags, "PowerManagementPlugin");
 			try {
@@ -104,30 +104,35 @@ public class PowerManagement extends CordovaPlugin {
 		else {
 			result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION,"WakeLock already active - release first");
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Release an active wake-lock
 	 * @return PluginResult containing the status of the release process
 	 */
 	private PluginResult release() {
 		PluginResult result = null;
-		
+
 		if( this.wakeLock != null ) {
-			this.wakeLock.release();
+			try {
+				this.wakeLock.release();
+				result = new PluginResult(PluginResult.Status.OK, "OK");
+			}
+			catch (Exception e) {
+				result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, "WakeLock already released");
+			}
+
 			this.wakeLock = null;
-			
-			result = new PluginResult(PluginResult.Status.OK, "OK");
 		}
 		else {
 			result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, "No WakeLock active - acquire first");
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Make sure any wakelock is released if the app goes into pause
 	 */
@@ -137,7 +142,7 @@ public class PowerManagement extends CordovaPlugin {
 
 		super.onPause(multitasking);
 	}
-	
+
 	/**
 	 * Make sure any wakelock is acquired again once we resume
 	 */

--- a/www/powermanagement.js
+++ b/www/powermanagement.js
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013 Wolfgang Koller
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ var PowerManagement = function() {};
 
 /**
  * Acquire a new wake-lock (keep device awake)
- * 
+ *
  * @param successCallback function to be called when the wake-lock was acquired successfully
  * @param errorCallback function to be called when there was a problem with acquiring the wake-lock
  */
@@ -29,12 +29,23 @@ PowerManagement.prototype.acquire = function(successCallback,failureCallback, ru
 
 /**
  * Release the wake-lock
- * 
+ *
  * @param successCallback function to be called when the wake-lock was released successfully
  * @param errorCallback function to be called when there was a problem while releasing the wake-lock
  */
 PowerManagement.prototype.release = function(successCallback,failureCallback) {
     cordova.exec(successCallback, failureCallback, 'PowerManagement', 'release', []);
+}
+
+/**
+ * Enable or disable releasing of the wakelock on pause
+ *
+ * @param enabled boolean - true to enable releasing of wakelock on pause, or false to disable
+ * @param successCallback
+ * @param errorCallback
+ */
+PowerManagement.prototype.setReleaseOnPause = function(enabled, successCallback, failureCallback) {
+    cordova.exec(successCallback, failureCallback, 'PowerManagement', 'setReleaseOnPause', [enabled]);
 }
 
 /**


### PR DESCRIPTION
I've fixed #6 this as per the solution in the issue, by simply surrounding the release with a try / catch block.

I have also added a function for Android to allow the disabling of wakelock release on pause. This is for my use case where the screen will be off most of the time the wakelock is enabled. I added usage for it to the readme, along with the existing functions.