### PR TITLE
iOS: remove use of deprecated cordova API

### DIFF
--- a/src/ios/PowerManagement.m
+++ b/src/ios/PowerManagement.m
@@ -26,8 +26,6 @@
 - (void) acquire:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* result = nil;
-    NSString* jsString = nil;
-    NSString* callbackId = command.callbackId;
     
     // Acquire a reference to the local UIApplication singleton
     UIApplication* app = [UIApplication sharedApplication];
@@ -36,22 +34,18 @@
         [app setIdleTimerDisabled:true];
         
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        jsString = [result toSuccessCallbackString:callbackId];
     }
     else {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION messageAsString:@"IdleTimer already disabled"];
-        jsString = [result toErrorCallbackString:callbackId];
     }
     
-    [self writeJavascript:jsString];
+	[self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }
 
 
 - (void) release:(CDVInvokedUrlCommand*)command
 {    
     CDVPluginResult* result = nil;
-    NSString* jsString = nil;
-    NSString* callbackId = command.callbackId;
     
     // Acquire a reference to the local UIApplication singleton
     UIApplication* app = [UIApplication sharedApplication];
@@ -60,13 +54,11 @@
         [app setIdleTimerDisabled:false];
         
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        jsString = [result toSuccessCallbackString:callbackId];
     }
     else {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION messageAsString:@"IdleTimer not disabled"];
-        jsString = [result toErrorCallbackString:callbackId];
     }
     
-    [self writeJavascript:jsString];
+	[self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }
 @end


### PR DESCRIPTION
fix build issue when using plugin with Cordova iOS 4.0.0 (~ Cordova 6.0)
