### PR TITLE
Fix with additional wakelock level in Android.

### DIFF
--- a/src/android/PowerManagement.java
+++ b/src/android/PowerManagement.java
@@ -68,7 +68,7 @@ public class PowerManagement extends CordovaPlugin {
 					result = this.acquire( PowerManager.SCREEN_DIM_WAKE_LOCK );
 				}
 				else {
-					result = this.acquire( PowerManager.FULL_WAKE_LOCK );
+					result = this.acquire( PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP );
 				}
 			} else if( action.equals("release") ) {
 				result = this.release();


### PR DESCRIPTION
Without "PowerManager.ACQUIRE_CAUSES_WAKEUP" flag, 
android screen is not turned on.
