### PR TITLE
Turn off hardware buttons backlight on wake lock acquire

### DIFF
--- a/src/android/PowerManagement.java
+++ b/src/android/PowerManagement.java
@@ -68,7 +68,7 @@ public class PowerManagement extends CordovaPlugin {
 					result = this.acquire( PowerManager.SCREEN_DIM_WAKE_LOCK );
 				}
 				else {
-					result = this.acquire( PowerManager.FULL_WAKE_LOCK );
+					result = this.acquire( PowerManager.SCREEN_BRIGHT_WAKE_LOCK );
 				}
 			} else if( action.equals("release") ) {
 				result = this.release();


### PR DESCRIPTION
Changes wake lock mode from `FULL_WAKE_LOCK` to `SCREEN_BRIGHT_WAKE_LOCK` thus saving some battery juice on long running wake locks. Refer [android docs](https://developer.android.com/reference/android/os/PowerManager.html)